### PR TITLE
Use hostname from URI when server_host is None

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -73,7 +73,8 @@ class Connection:
         URL (str, Sequence): Broker URL, or a list of URLs.
 
     Keyword Arguments:
-        ssl (bool): Use SSL to connect to the server. Default is ``False``.
+        ssl (bool/dict): Use SSL to connect to the server.
+            Default is ``False``.
             May not be supported by the specified transport.
         transport (Transport): Default transport if not specified in the URL.
         connect_timeout (float): Timeout in seconds for connecting to the


### PR DESCRIPTION
This PR adds support for using hostname from URI in `server_hostname` parameter of `ssl` when `server_hostname` is None. This is useful for failovers.
